### PR TITLE
Small fixes to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ devToolsProject.run(
         String stdout = data.venv.run(
           label: 'ansible-lint',
           returnStdout: true,
-          script: 'ansible-lint -c .ansible-lint.yml',
+          script: 'ansible-lint --offline -c .ansible-lint.yml',
         )
 
         // If only warnings are found, ansible-lint will exit with code 0 but still write

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,.venv
+exclude = .ansible,.git,.venv
 filename = *.py
 ignore = W503
 max-line-length = 90


### PR DESCRIPTION
This PR (hopefully) fixes an issue where ansible-lint would install roles to the node's user cache directory, which could cause problems when running CI for those roles later. Also, it adds the  directory to the list of things that  should ignore as a preemptive measure.