### PR TITLE
Use new ansibleUtils singleton functions

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,6 +1,6 @@
 ---
 exclude_paths:
-  - .ansible/roles
+  - .ansible
   - .venv
   - molecule/*/converge.yml
 parseable: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 library(identifier: 'ableton-utils@0.22', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
-library(identifier: 'python-utils@0.12', changelog: false)
+library(identifier: 'python-utils@0.13', changelog: false)
 
 
 devToolsProject.run(
@@ -10,7 +10,7 @@ devToolsProject.run(
     // on our CI system once it discovers that roles with different versions are there.
     sh 'rm -rf $HOME/.cache/ansible-compat'
 
-    Object venv = virtualenv.createWithPyenv(readFile('.python-version'))
+    Object venv = pyenv.createVirtualEnv(readFile('.python-version'))
     venv.run('pip install -r requirements-dev.txt')
     data['rolesPath'] = "${env.WORKSPACE}/.ansible/roles"
     venv.run("ansible-galaxy install --no-deps --roles-path ${data.rolesPath}" +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,17 +5,10 @@ library(identifier: 'python-utils@0.13', changelog: false)
 
 devToolsProject.run(
   setup: { data ->
-    // Temporary workaround for molecule's awful handling of roles and collections. It
-    // insists on installing everything to ~/.cache/ansible-compat, which causes problems
-    // on our CI system once it discovers that roles with different versions are there.
-    sh 'rm -rf $HOME/.cache/ansible-compat'
-
     Object venv = pyenv.createVirtualEnv(readFile('.python-version'))
     venv.inside {
       sh 'pip install -r requirements-dev.txt'
-      data['rolesPath'] = "${env.WORKSPACE}/.ansible/roles"
-      sh "ansible-galaxy install --no-deps --roles-path ${data.rolesPath}" +
-        " git+https://github.com/${params.JENKINS_REPO_SLUG},${params.JENKINS_COMMIT}"
+      ansibleUtils.galaxyInstall()
     }
     data['venv'] = venv
   },
@@ -29,32 +22,13 @@ devToolsProject.run(
           )
         },
         groovylint: { groovylint.checkSingleFile(path: './Jenkinsfile') },
-        molecule: {
-          withEnv(["ANSIBLE_ROLES_PATH=${data.rolesPath}"]) {
-            sh 'molecule --debug test'
-          }
-        },
+        molecule: { ansibleUtils.molecule() },
         yamllint: { sh 'yamllint --strict .' },
       )
     }
   },
   deployWhen: { devToolsProject.shouldDeploy(defaultBranch: 'main') },
   deploy: { data ->
-    String versionNumber = readFile('VERSION').trim()
-    version.tag(versionNumber)
-
-    List repoSlugParts = params.JENKINS_REPO_SLUG.split('/')
-    String repoOrg = repoSlugParts[0]
-    String repoName = repoSlugParts[1]
-    withCredentials([
-      string(credentialsId: 'ansible-galaxy-api-key', variable: 'API_KEY')
-    ]) {
-      data.venv.run(
-        label: 'Publish to Ansible Galaxy',
-        script: "ansible-galaxy role import --branch ${versionNumber}" +
-          ' --api-key $API_KEY' +  // avoid exposing the credential in the build log
-          " ${repoOrg} ${repoName}",
-      )
-    }
+    data.venv.inside { ansibleUtils.publishRole('ansible-galaxy-api-key') }
   },
 )

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,4 +1,5 @@
 ---
+prerun: false
 dependency:
   name: galaxy
 driver:


### PR DESCRIPTION
- Ignore entire .ansible directory for ansible-lint
- Update python-utils to 0.13
- Use venv.inside instead of multiple venv.run calls
- Use new ansibleUtils singleton functions
