### PR TITLE
Remove community.docker role

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,7 @@ library(identifier: 'python-utils@0.13', changelog: false)
 devToolsProject.run(
   setup: { data ->
     Object venv = pyenv.createVirtualEnv(readFile('.python-version'))
-    venv.inside {
-      sh 'pip install -r requirements-dev.txt'
-      ansibleUtils.galaxyInstall()
-    }
+    venv.run('pip install -r requirements-dev.txt')
     data['venv'] = venv
   },
   test: { data ->

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,0 @@
----
-collections:
-  - name: community.docker
-    version: 3.2.2


### PR DESCRIPTION
This role was previously needed for the molecule-docker package, but in version 2.1.0 this dependency was fixed, so we shouldn't need to add this collection to our requirements.yml file anymore.