### PR TITLE
Fix support for macOS

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
       (ansible_os_family == "Darwin" and not nix_directory_mac.stat.exists)
 
 - name: Install Nix
-  when: nix_directory is changed  # noqa no-handler
+  when: should_install_nix  # noqa no-handler
   block:
     - name: Download installer script
       ansible.builtin.get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,15 +41,10 @@
   when: ansible_os_family != "Darwin"
   register: nix_directory
 
-- name: Set should_install_nix fact
-  ansible.builtin.set_fact:
-    should_install_nix: true
-    when: >
-      (ansible_os_family != "Darwin" and nix_directory is changed) or
-      (ansible_os_family == "Darwin" and not nix_directory_mac.stat.exists)
-
 - name: Install Nix
-  when: should_install_nix  # noqa no-handler
+  when: >
+    (ansible_os_family != "Darwin" and nix_directory is changed) or
+    (ansible_os_family == "Darwin" and not nix_directory_mac.stat.exists)
   block:
     - name: Download installer script
       ansible.builtin.get_url:


### PR DESCRIPTION
macOS support was recently
[added](https://github.com/Ableton/ansible-role-nix/pull/121/files), but it contained a small omission:

The "Install Nix" task wasn't changed to use the newly-introduced `should_install_nix` fact.  Correct that oversight.

(As an aside, [this](https://github.com/Ableton/ansible-role-nix/issues/119#issuecomment-1457955755) made me smile:
> If you could try out this branch and let me know if it works, that would be very useful, as I don't have a Mac to test on. Otherwise it "should work" (famous last words 😅).

That's always how this kind of thing goes.)
