### PR TITLE
Update Molecule to 5.0

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,4 @@
 ansible-core
 ansible-lint
 molecule
-molecule-docker
+molecule-plugins[docker]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ ansible-core==2.14.4
     #   -r requirements-dev.in
     #   ansible-compat
     #   ansible-lint
+    #   molecule
 ansible-lint==6.14.6
     # via -r requirements-dev.in
 arrow==1.2.3
@@ -46,7 +47,7 @@ cryptography==40.0.2
 distro==1.8.0
     # via selinux
 docker==6.0.1
-    # via molecule-docker
+    # via molecule-plugins
 enrich==1.2.7
     # via molecule
 filelock==3.11.0
@@ -72,11 +73,11 @@ markupsafe==2.1.2
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-molecule==4.0.4
+molecule==5.0.0
     # via
     #   -r requirements-dev.in
-    #   molecule-docker
-molecule-docker==2.1.0
+    #   molecule-plugins
+molecule-plugins[docker]==23.4.1
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via black
@@ -118,7 +119,7 @@ requests==2.28.2
     # via
     #   cookiecutter
     #   docker
-    #   molecule-docker
+    #   molecule-plugins
 resolvelib==0.8.1
     # via ansible-core
 rich==13.3.4
@@ -131,7 +132,7 @@ ruamel-yaml==0.17.21
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 selinux==0.3.0
-    # via molecule-docker
+    # via molecule-plugins
 six==1.16.0
     # via python-dateutil
 subprocess-tee==0.4.1


### PR DESCRIPTION
Molecule 5.0 now requires the molecule-plugins[docker] package. The molecule-docker package is deprecated and its GitHub page has been archived.