### PR TITLE
Fix linting issues

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -2,7 +2,6 @@
 exclude_paths:
   - .ansible
   - .venv
-  - molecule/*/converge.yml
 parseable: true
 skip_list:
   - "empty-string-compare"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,7 +13,7 @@
     - name: Get list of installed Nix packages
       become: true
       become_user: "{{ nix_user }}"
-      shell: "nix-env --query --installed"
+      ansible.builtin.command: "nix-env --query --installed"
       environment:
         PATH: "/home/{{ nix_user }}/.nix-profile/bin:{{ lookup('env', 'PATH') }}"
       changed_when: false
@@ -22,29 +22,30 @@
     - name: Try to install a Nix package
       become: true
       become_user: "{{ nix_user }}"
-      shell: "nix-env -i hello"
+      ansible.builtin.command: "nix-env -i hello"
       environment:
         PATH: "/home/{{ nix_user }}/.nix-profile/bin:{{ lookup('env', 'PATH') }}"
       when: "'hello' not in nix_packages.stdout"
+      changed_when: true
 
     - name: Try to run the hello Nix package
       become: true
       become_user: "{{ nix_user }}"
-      command: "hello"
+      ansible.builtin.command: "hello"
       environment:
         PATH: "/home/{{ nix_user }}/.nix-profile/bin:{{ lookup('env', 'PATH') }}"
       changed_when: false
       register: hello_output
 
     - name: Verify output of the hello program
-      fail:
+      ansible.builtin.fail:
         msg: "The hello program did not return the expected output!"
       when: "hello_output.stdout != 'Hello, world!'"
 
     - name: Try to use Nix Flakes
       become: true
       become_user: "{{ nix_user }}"
-      shell: "nix flake metadata github:edolstra/dwarffs"
+      ansible.builtin.command: "nix flake metadata github:edolstra/dwarffs"
       environment:
         PATH: "/home/{{ nix_user }}/.nix-profile/bin:{{ lookup('env', 'PATH') }}"
       changed_when: false

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,3 +2,5 @@ ansible-core
 ansible-lint
 molecule
 molecule-plugins[docker]
+# https://github.com/docker/docker-py/issues/3113
+urllib3<2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -154,8 +154,9 @@ text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via black
-urllib3==2.0.3
+urllib3==1.26.16
     # via
+    #   -r requirements-dev.in
     #   docker
     #   requests
 wcmatch==8.4.1


### PR DESCRIPTION
I had a couple issues trying to run ansible-lint and molecule locally direct from a clone and install dependencies, that are fixed in this PR.

Namely:

1. ansible lint does not find role declared in converge:

   ```
   % ansible-lint
   WARNING  Skipped installing collection dependencies due to running in offline mode.
   WARNING  Listing 1 violation(s) that are fatal
   syntax-check[specific]: the role 'ansible-role-nix' was not found in /home/user/workspace/ansible-role-nix/molecule   /default/roles:/home/user/.cache/ansible-compat/1a0050/roles:/home/user/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/home/user/workspace/ansible-role-nix/molecule/default
   molecule/default/converge.yml:10:7
   ```

1. docker-py fails running molecule with (check https://github.com/docker/docker-py/issues/3113):

   ```
   Error while fetching server API version: request() got an unexpected keyword argument 'chunked'
   ```

   Adding a restriction to urllib3 solves the issue.

1. errors pointed by `molecule/default/coverage.yml` are also fixed, so the file does not need to be ignored anymore.
