### PR TITLE
Update ableton-utils to 0.24.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.23', changelog: false)
+library(identifier: 'ableton-utils@0.24', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,7 +7,7 @@
     nix_bind_mount: "/new/nix"
 
   roles:
-    - ansible-role-nix
+    - ableton.nix
 
   tasks:
     - name: Get list of installed Nix packages

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,4 @@
 ---
-prerun: false
 dependency:
   name: galaxy
 driver:


### PR DESCRIPTION
This update contains some improvements with how Ansible roles are tested with Molecule that will allow us to remove some of our hacks regarding role naming in the Molecule configuration files.