### PR TITLE
Remove dependency pins from requirements-dev.in

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,8 +1,4 @@
-ansible-core==2.17.1
+ansible-core
 ansible-lint
 molecule
 molecule-plugins[docker]
-# https://github.com/docker/docker-py/issues/3113
-urllib3<2
-# TODO: Remove this once Molecule has been fixed to work with requests >2.31
-requests==2.31.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -109,7 +109,6 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r requirements-dev.in
     #   docker
     #   molecule-plugins
 resolvelib==1.0.1
@@ -135,7 +134,6 @@ subprocess-tee==0.4.2
     #   ansible-lint
 urllib3==1.26.19
     # via
-    #   -r requirements-dev.in
     #   docker
     #   requests
 wcmatch==8.5.2


### PR DESCRIPTION
We don't need to explicitly pin these versions anymore, since the packages themselves now have pins to safeguard against these incompatibilities.